### PR TITLE
Use Semantic Versioning 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <dependency>
   <groupId>org.crac</groupId>
   <artifactId>crac</artifactId>
-  <version>0.1.3</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.crac</groupId>
   <artifactId>crac</artifactId>
-  <version>0.1.3</version>
+  <version>1.3.0</version>
   <packaging>jar</packaging>
 
   <name>crac</name>


### PR DESCRIPTION
Since the begining, org.crac used 0.x.y version, with a weak rule for version to follow [semver](https://semver.org/) scheme.

As more projects adopting org.crac, it's proposed to use the strict Semantic Versioning.