### PR TITLE
Expose JVM CRaCMXBean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.crac</groupId>
   <artifactId>crac</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>crac</name>

--- a/src/main/java/org/crac/management/CRaCImpl.java
+++ b/src/main/java/org/crac/management/CRaCImpl.java
@@ -1,0 +1,67 @@
+// Copyright 2022 Azul Systems, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.crac.management;
+
+import javax.management.ObjectName;
+import java.lang.management.PlatformManagedObject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+class CRaCImpl implements CRaCMXBean {
+
+    private final PlatformManagedObject platformImpl;
+    private final Method getUptimeSinceRestore;
+    private final Method getRestoreTime;
+
+    CRaCImpl(Class iface, PlatformManagedObject platformImpl)
+            throws NoSuchMethodException {
+        this.platformImpl = platformImpl;
+        this.getUptimeSinceRestore = iface.getMethod("getUptimeSinceRestore");
+        this.getRestoreTime = iface.getMethod("getRestoreTime");
+    }
+
+    @Override
+    public long getUptimeSinceRestore() {
+        try {
+            return (long)getUptimeSinceRestore.invoke(platformImpl);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public long getRestoreTime() {
+        try {
+            return (long)getRestoreTime.invoke(platformImpl);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+        return platformImpl.getObjectName();
+    }
+}

--- a/src/main/java/org/crac/management/CRaCMXBean.java
+++ b/src/main/java/org/crac/management/CRaCMXBean.java
@@ -1,0 +1,79 @@
+// Copyright 2022 Azul Systems, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.crac.management;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.PlatformManagedObject;
+import java.lang.management.RuntimeMXBean;
+
+/**
+ * Management interface for the CRaC functionality of the Java virtual machine.
+ */
+public interface CRaCMXBean extends PlatformManagedObject {
+
+    /**
+     * Returns the time since the Java virtual machine restore was initiated.
+     * If the machine was not restored, returns -1.
+     *
+     * @see RuntimeMXBean#getStartTime()
+     * @return uptime of the Java virtual machine in milliseconds.
+     */
+    public long getUptimeSinceRestore();
+
+    /**
+     * Returns the time when the Java virtual machine restore was initiated.
+     * The value is the number of milliseconds since the start of the epoch.
+     * If the machine was not restored, returns -1.
+     *
+     * @see RuntimeMXBean#getUptime()
+     * @return start time of the Java virtual machine in milliseconds.
+     */
+    public long getRestoreTime();
+
+    /**
+     * Returns the implementation of the MXBean.
+     *
+     * @throws UnsupportedOperationException if the virtual machine does not provide MXBean implementation
+     * @return implementation of the MXBean.
+     */
+    public static CRaCMXBean getCRaCMXBean() {
+        Class iface;
+        try {
+            iface = Class.forName("jdk.crac.management.CRaCMXBean");
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException(e);
+        }
+        PlatformManagedObject impl = ManagementFactory.getPlatformMXBean(iface);
+        if (impl == null) {
+            throw new UnsupportedOperationException(
+                    "Platform CRaCMXBean found, but no Platform MXBean implementation");
+        }
+        try {
+            return new CRaCImpl(iface, impl);
+        } catch (NoSuchMethodException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+}

--- a/src/main/java/org/crac/management/package-info.java
+++ b/src/main/java/org/crac/management/package-info.java
@@ -1,0 +1,29 @@
+// Copyright 2022 Azul Systems, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * This package contains management interfaces for CRaC.
+ */
+
+package org.crac.management;


### PR DESCRIPTION
Exposes JVM interface for timing of restoration added in CRaC EA [17+4](https://github.com/CRaC/openjdk-builds/releases/tag/17-crac%2B4) ([API for restore time](https://github.com/openjdk/crac/pull/29))

`UnsupportedOperationException` is thrown on JVMs without corresponding functionality.