### PR TITLE
Make CRaCMXBean always available

### DIFF
--- a/src/main/java/org/crac/management/CRaCMXBean.java
+++ b/src/main/java/org/crac/management/CRaCMXBean.java
@@ -55,7 +55,6 @@ public interface CRaCMXBean extends PlatformManagedObject {
     /**
      * Returns the implementation of the MXBean.
      *
-     * @throws UnsupportedOperationException if the virtual machine does not provide MXBean implementation
      * @return implementation of the MXBean.
      */
     public static CRaCMXBean getCRaCMXBean() {
@@ -63,17 +62,16 @@ public interface CRaCMXBean extends PlatformManagedObject {
         try {
             iface = Class.forName("jdk.crac.management.CRaCMXBean");
         } catch (ClassNotFoundException e) {
-            throw new UnsupportedOperationException(e);
+            return new NoImpl();
         }
         PlatformManagedObject impl = ManagementFactory.getPlatformMXBean(iface);
         if (impl == null) {
-            throw new UnsupportedOperationException(
-                    "Platform CRaCMXBean found, but no Platform MXBean implementation");
+            return new NoImpl();
         }
         try {
             return new CRaCImpl(iface, impl);
         } catch (NoSuchMethodException e) {
-            throw new UnsupportedOperationException(e);
+            return new NoImpl();
         }
     }
 }

--- a/src/main/java/org/crac/management/NoImpl.java
+++ b/src/main/java/org/crac/management/NoImpl.java
@@ -1,0 +1,45 @@
+// Copyright 2023 Azul Systems, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.crac.management;
+
+import javax.management.ObjectName;
+
+class NoImpl implements CRaCMXBean {
+
+    @Override
+    public long getUptimeSinceRestore() {
+        return -1;
+    }
+
+    @Override
+    public long getRestoreTime() {
+        return -1;
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+        return null;
+    }
+}

--- a/src/main/java/org/crac/management/NoImpl.java
+++ b/src/main/java/org/crac/management/NoImpl.java
@@ -26,6 +26,10 @@ package org.crac.management;
 
 import javax.management.ObjectName;
 
+/**
+ * On a VM without CRaC implementation, the checkpoint and restoration are impossible.
+ * So a simple implementation reporting no restoration has happened is valid.
+ */
 class NoImpl implements CRaCMXBean {
 
     @Override


### PR DESCRIPTION
Simplifies the interface of CRaCMXBean, the bean always exists. In case the underlying VM does not provide CRaC functionality, the no-op bean implementation always reports timing corresponding to no restoration, as restoration cannot happen without checkpoint implementation.

Alternative implementation of getCRaCMXBean may return `null` on a JVM without CRaC implementation. It will make interface a bit harder to use, requiring null checks. And it will also prevent future extension of CRaCMXBean with methods which do not require CRaC implementation in the VM. An example is a method reporting if CRaC implementation is no-op or not.