### PR TITLE
Add generation of OSGi metadata and JPMS module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,34 @@
         <version>3.0.1</version>
         <configuration>
           <tagNameFormat>@{project.version}</tagNameFormat>
-	  <scmCommentPrefix>[release]</scmCommentPrefix>
-	  <pushChanges>false</pushChanges>
+          <scmCommentPrefix>[release]</scmCommentPrefix>
+          <pushChanges>false</pushChanges>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>6.4.0</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+              -noextraheaders: true
+              -noimportjava: true
+              Bundle-Name: org.crac
+              Bundle-SymbolicName: org.crac
+              Import-Package: javax.crac;resolution:=optional, jdk.crac;resolution:=optional, jdk.crac.management;resolution:=optional, *
+              package-version=${versionmask;===;${Bundle-Version}}
+              Export-Package: *;version="${package-version}";-noimport:=true
+              -jpms-module-info: org.crac;version="${package-version}"
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
As per our discussion in https://github.com/osgi/osgi/issues/631 I am working on a more useful example of a containerized OSGi application. I want to setup a REST service application using Jakarta RS Whiteboard and put that in a container with checkpoint data.

While trying to create a `Resource` to handle the checkpoint/restore operations (see https://github.com/osgi/jakartarest-osgi/commit/2ac4d8f4c616d248161e69c9877e9e403b844fa9) I noticed that org.crac does not contain OSGi metadata. It is therefore not possible to use it easily.

The following PR adds the necessary build step to add OSGi metadata to the jar file. Additionally it also adds a JPMS module-info.class to the jar. Once this is merged and released I can move on with a PR for the Jakarta-RS Whiteboard, and then provide the example for CRaC`in an OSGi application.